### PR TITLE
feat: near DA for daserver

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.2.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.0/direnvrc" "sha256-5EwyKnkJNQeXrRkYbwwRBcXbibosCJqyIUuz9Xq+LRc="
+fi
+
+source .env
+# NIXPKGS_ALLOW_INSECURE=1
+# use flake --impure
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ local/
 system_tests/test-data/*
 system_tests/testdata/*
 arbos/testdata/*
+
+
+.direnv
+rollup-data-availability
+nitro.log
+orbit-setup-script
+
+.config/

--- a/Makefile
+++ b/Makefile
@@ -16,19 +16,19 @@ endif
 
 
 ifneq ($(origin NITRO_VERSION),undefined)
- GOLANG_LDFLAGS += -X github.com/offchainlabs/nitro/cmd/util/confighelpers.version=$(NITRO_VERSION)
+ GOLANG_LDFLAGS += -X github.com/offchainlabs/nitro/cmd/util/confighelpers.version=$(NITRO_VERSION) --allow-multiple-definition
 endif
 
 ifneq ($(origin NITRO_DATETIME),undefined)
- GOLANG_LDFLAGS += -X github.com/offchainlabs/nitro/cmd/util/confighelpers.datetime=$(NITRO_DATETIME)
+ GOLANG_LDFLAGS += -X github.com/offchainlabs/nitro/cmd/util/confighelpers.datetime=$(NITRO_DATETIME) --allow-multiple-definition
 endif
 
 ifneq ($(origin NITRO_MODIFIED),undefined)
- GOLANG_LDFLAGS += -X github.com/offchainlabs/nitro/cmd/util/confighelpers.modified=$(NITRO_MODIFIED)
+ GOLANG_LDFLAGS += -X github.com/offchainlabs/nitro/cmd/util/confighelpers.modified=$(NITRO_MODIFIED) --allow-multiple-definition
 endif
 
 ifneq ($(origin GOLANG_LDFLAGS),undefined)
- GOLANG_PARAMS = -ldflags="$(GOLANG_LDFLAGS)"
+ GOLANG_PARAMS = -ldflags="$(GOLANG_LDFLAGS)" --allow-multiple-definition
 endif
 
 precompile_names = AddressTable Aggregator BLS Debug FunctionTable GasInfo Info osTest Owner RetryableTx Statistics Sys

--- a/das/das.go
+++ b/das/das.go
@@ -53,6 +53,7 @@ type DataAvailabilityConfig struct {
 
 	RPCAggregator  AggregatorConfig              `koanf:"rpc-aggregator"`
 	RestAggregator RestfulClientAggregatorConfig `koanf:"rest-aggregator"`
+	NEARAggregator NearAggregatorConfig          `koanf:"near-aggregator"`
 
 	ParentChainNodeURL              string `koanf:"parent-chain-node-url"`
 	ParentChainConnectionAttempts   int    `koanf:"parent-chain-connection-attempts"`
@@ -132,6 +133,7 @@ func dataAvailabilityConfigAddOptions(prefix string, f *flag.FlagSet, r role) {
 	// Both the Nitro node and daserver can use these options.
 	IpfsStorageServiceConfigAddOptions(prefix+".ipfs-storage", f)
 	RestfulClientAggregatorConfigAddOptions(prefix+".rest-aggregator", f)
+	NearAggregatorConfigAddOptions(prefix+".near-aggregator", f)
 
 	f.String(prefix+".parent-chain-node-url", DefaultDataAvailabilityConfig.ParentChainNodeURL, "URL for parent chain node, only used in standalone daserver; when running as part of a node that node's L1 configuration is used")
 	f.Int(prefix+".parent-chain-connection-attempts", DefaultDataAvailabilityConfig.ParentChainConnectionAttempts, "parent chain RPC connection attempts (spaced out at least 1 second per attempt, 0 to retry infinitely), only used in standalone daserver; when running as part of a node that node's parent chain configuration is used")

--- a/das/near_aggregator.go
+++ b/das/near_aggregator.go
@@ -1,0 +1,167 @@
+package das
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	near "github.com/near/rollup-data-availability/gopkg/da-rpc"
+	"github.com/offchainlabs/nitro/arbstate"
+	"github.com/offchainlabs/nitro/blsSignatures"
+	flag "github.com/spf13/pflag"
+)
+
+// TODO: inject in place of RPC aggregator
+type NearService struct {
+	near near.Config
+	pub  blsSignatures.PublicKey
+	priv blsSignatures.PrivateKey
+}
+
+func NewNearService(config DataAvailabilityConfig) (*NearService, error) {
+
+	privKey, err := DecodeBase64BLSPrivateKey([]byte(config.Key.PrivKey))
+	if err != nil {
+		return nil, err
+	}
+
+	pubKey, err := blsSignatures.PublicKeyFromPrivateKey(privKey)
+	if err != nil {
+		return nil, err
+	}
+
+	near, err := near.NewConfig(config.NEARAggregator.Account, config.NEARAggregator.Contract, config.NEARAggregator.Key, config.NEARAggregator.Namespace)
+
+	return &NearService{
+		near: *near,
+		pub:  pubKey,
+		priv: privKey,
+	}, nil
+}
+
+func (s *NearService) String() string {
+	return fmt.Sprintf("NearService{}")
+}
+
+type NearAggregatorConfig struct {
+	Enable    bool
+	Account   string
+	Contract  string
+	Key       string
+	Namespace uint32
+	StorageConfig NearStorageConfig `koanf:"storage"`
+}
+
+func NewNearAggregator(ctx context.Context, config DataAvailabilityConfig, nsvc *NearService) (*Aggregator, error) {
+	svc := ServiceDetails{
+		service:     (DataAvailabilityServiceWriter)(nsvc),
+		pubKey:      nsvc.pub,
+		signersMask: 1,
+		metricName:  "near",
+	}
+
+	services := make([]ServiceDetails, 1)
+	services[0] = svc
+
+	return NewAggregator(ctx, config, services)
+}
+
+func (s *NearService) Store(ctx context.Context, message []byte, timeout uint64, sig []byte) (*arbstate.DataAvailabilityCertificate, error) {
+	log.Info("Storing message", "message", message)
+	frameRefBytes, err := s.near.ForceSubmit(message)
+	if err != nil {
+		return nil, err
+	}
+	frameRef := near.FrameRef{}
+	err = frameRef.UnmarshalBinary(frameRefBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	keysetHash, keySet, err := s.KeysetHash()
+	if err != nil {
+		log.Error("Error getting keyset hash", "err", err, "keyset", keySet)
+		return nil, err
+	}
+	var certificate = arbstate.DataAvailabilityCertificate{
+		KeysetHash:  keysetHash,
+		DataHash:    [32]byte(frameRef.TxId),
+		Timeout:     timeout,
+		Sig:         nil,
+		SignersMask: 1,
+		Version: 255,
+	}
+	newSig, err := blsSignatures.SignMessage(s.priv, certificate.SerializeSignableFields())
+	if err != nil {
+		return nil, err
+	}
+	certificate.Sig = newSig
+
+	return &certificate, nil
+}
+
+func (s *NearService) KeysetHash() ([32]byte, []byte, error) {
+	svc := ServiceDetails{
+		service:     (DataAvailabilityServiceWriter)(s),
+		pubKey:      s.pub,
+		signersMask: 1,
+		metricName:  "near",
+	}
+
+	services := make([]ServiceDetails, 1)
+	services[0] = svc
+	return KeysetHashFromServices(services, 1)
+}
+
+func (s *NearService) GetByHash(ctx context.Context, hash common.Hash) ([]byte, error) {
+	log.Info("Getting message", "hash", hash)
+	// Hack to bypass commitment
+	bytesPadded := make([]byte, 64)
+	copy(bytesPadded[0:32], hash.Bytes())
+	bytes, err := s.near.Get(bytesPadded, 0)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+
+}
+
+func (s *NearService) ExpirationPolicy(ctx context.Context) (arbstate.ExpirationPolicy, error) {
+	return arbstate.KeepForever, nil
+}
+
+var DefaultNearAggregatorConfig = NearAggregatorConfig{
+	Enable:    true,
+	Account:   "topgunbakugo.testnet",
+	Contract:  "nitro.topgunbakugo.testnet",
+	Key:       "ed25519:kjdshdfskjdfhsdk",
+	Namespace: 1,
+	StorageConfig: DefaultNearStorageConfig,
+}
+
+func NearAggregatorConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.Bool(prefix+".enable", DefaultNearAggregatorConfig.Enable, "enable retrieval of sequencer batch data from a list of remote REST endpoints; if other DAS storage types are enabled, this mode is used as a fallback")
+	f.String(prefix+".account", DefaultNearAggregatorConfig.Account, "Account Id for signing NEAR transactions")
+	f.String(prefix+".contract", DefaultNearAggregatorConfig.Contract, "Contract address for submitting NEAR transactions")
+	f.String(prefix+".key", DefaultNearAggregatorConfig.Key, "ED25519 Key for signing NEAR transactions, prefixed with 'ed25519:'")
+	f.Uint32(prefix+".namespace", DefaultNearAggregatorConfig.Namespace, "Namespace for this rollup")
+  NearStorageConfigAddOptions(prefix+".storage", f)	
+}
+
+// TODO: add healtchecks
+func (s *NearService) HealthCheck(ctx context.Context) error {
+	s.near.Get(nil, 0)
+	return nil
+}
+
+func (s *NearService) Put(ctx context.Context, data []byte, expirationTime uint64) error {
+	log.Info("Storing message", "message", data)
+	frameRefBytes, err := s.near.ForceSubmit(data)
+	if err != nil {
+		return err
+	}
+	log.Info("Frame ref", "frame ref", hex.EncodeToString(frameRefBytes))
+	return nil
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,147 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "unstable": "unstable"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1701051362,
+        "narHash": "sha256-3dXjewnLylWGZKNshIV0eiabhIDjcUNXC5zRKcm0TxY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "055d3d2ea161dfc6ca569f2f135a107f48cf483e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "unstable": {
+      "locked": {
+        "lastModified": 1700794826,
+        "narHash": "sha256-RyJTnTNKhO0yqRpDISk03I/4A67/dp96YRxc86YOPgU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5a09cb4b393d58f9ed0d9ca1555016a8543c2ac8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "Development nix flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/23.05";
+    unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, unstable, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ 
+          (import rust-overlay) 
+       ];
+        pkgs = import nixpkgs { inherit system overlays; };
+        pkgs-unstable = import unstable { inherit system overlays; };
+        rustVersion = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = rustVersion;
+          rustc = rustVersion;
+        };
+      in {
+        #stdenv = pkgs.clangStdenv;
+        devShell = pkgs.mkShell {
+          LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
+          NIXPKGS_ALLOW_INSECURE=1;
+          LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib/:/usr/local/lib";
+
+          # TODO: Fix this in this flake
+          # cp -r /nix/store/6cxi0nn9jbwjf21smbx11znw3gc9cjb8-emscripten-3.1.47/share/emscripten/cache ~/.emscripten_cache
+          # chmod u+rwX -R ~/.emscripten_cache
+          EM_CACHE="~/.emscripten_cache";
+
+
+          nativeBuildInputs = with pkgs; [
+            bashInteractive
+            emscripten
+            taplo
+            cmake
+            openssl
+            pkg-config
+            pkgs-unstable.nodejs
+            pkgs-unstable.yarn
+            # clang
+            llvmPackages_12.bintools
+            llvmPackages_12.libclang
+            protobuf
+            rust-cbindgen
+            
+            # Should be go 1.19
+            go
+			      govendor
+            gopls
+            python3Full
+
+          ];
+          buildInputs = with pkgs; [
+              (rustVersion.override { extensions = [ "rust-src" ]; })
+          ];
+          permittedInsecurePackages = [
+          ];
+
+        };
+  });
+}

--- a/go.mod
+++ b/go.mod
@@ -247,6 +247,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/samber/lo v1.36.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/supranational/blst v0.3.11-0.20230406105308-e9dfc5ee724b // indirect
 	github.com/urfave/cli/v2 v2.24.1 // indirect
@@ -326,6 +327,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/mapstructure v1.4.2
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
+	github.com/near/rollup-data-availability v0.2.4-0.20231212152220-c8df23efc3e5
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/rs/cors v1.7.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1348,6 +1348,12 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/near/rollup-data-availability v0.2.3 h1:sI203UYVCq030PdMacH96MvT5W26RMiY5A7qUe7AoqM=
+github.com/near/rollup-data-availability v0.2.3/go.mod h1:kzQi3/MdPKkid8rxflyA9oEBlaLAewXJMqCBXStBxQo=
+github.com/near/rollup-data-availability v0.2.4-0.20231212151928-61861f6fabc8 h1:qulTO1sGRooOFXfrSxA/6lMVmbzAutIwE0PZZxC52xk=
+github.com/near/rollup-data-availability v0.2.4-0.20231212151928-61861f6fabc8/go.mod h1:kzQi3/MdPKkid8rxflyA9oEBlaLAewXJMqCBXStBxQo=
+github.com/near/rollup-data-availability v0.2.4-0.20231212152220-c8df23efc3e5 h1:aeC9XiKG6CijBjAHHvexoyn+IN8X5FkOK0RrnGorECQ=
+github.com/near/rollup-data-availability v0.2.4-0.20231212152220-c8df23efc3e5/go.mod h1:kzQi3/MdPKkid8rxflyA9oEBlaLAewXJMqCBXStBxQo=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
@@ -1539,6 +1545,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
@@ -2002,6 +2010,7 @@ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+# This specifies the version of Rust we use to build.
+# Individual crates in the workspace may support a lower version, as indicated by `rust-version` field in each crate's `Cargo.toml`.
+# The version specified below, should be at least as high as the maximum `rust-version` within the workspace.
+channel    = "1.72.0"
+components = [ "rustfmt", "rust-src" ]
+targets    = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Introduces a store for looking up daserver hashes to txids


## To test:

Build daserver/datool:
`make target/bin/daserver && make target/bin/datool`

Deploy contract, update daserver config to introduce new fields:
```
 "near-aggregator": {
      "enable": true,
      "key": "ed25519:insert_here",
      "account": "helloworld.testnet",
      "contract": "your_deployed_da_contract.testnet",
      "storage": {
        "enable": true,
        "data-dir": "config/near-storage"
      }
    },
```

`target/bin/datool client rpc store  --url http://localhost:7876 --message "Hello worl" --signing-key config/daserverkeys/ecdsa`

Take data hash, check the output as so
`target/bin/datool client rest getbyhash --url http://localhost:7877 --data-hash 0xea7c19deb86746af7e65c131e5040dbd5dcce8ecb3ca326ca467752e72915185`
